### PR TITLE
Fix selection prompt boundary check and add regression test

### DIFF
--- a/Consoul.Tests/Consoul.Tests.csproj
+++ b/Consoul.Tests/Consoul.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Consoul\Consoul.csproj" />
+  </ItemGroup>
+</Project>

--- a/Consoul.Tests/Prompt/SelectionPromptTests.cs
+++ b/Consoul.Tests/Prompt/SelectionPromptTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using ConsoulLibrary;
+using Xunit;
+
+namespace Consoul.Tests.Prompt
+{
+    public class SelectionPromptTests
+    {
+        [Fact]
+        public void Render_RepeatsWhenSelectionExceedsOptionCount()
+        {
+            var routine = new TestRoutine(new[]
+            {
+                new RoutineInput { Value = "4" },
+                new RoutineInput { Value = "1" }
+            });
+
+            Routines.InitializeRoutine(routine);
+
+            try
+            {
+                var prompt = new SelectionPrompt("Pick an option", clear: false, "Alpha", "Beta", "Gamma");
+
+                PromptResult result = prompt.Render();
+
+                Assert.True(result.HasSelection);
+                Assert.Equal(0, result.Index);
+            }
+            finally
+            {
+                Routines.InitializeRoutine(new TestRoutine(Array.Empty<RoutineInput>()));
+            }
+        }
+
+        private sealed class TestRoutine : Routine
+        {
+            public TestRoutine(IEnumerable<RoutineInput> inputs)
+            {
+                foreach (var input in inputs)
+                {
+                    Enqueue(input);
+                }
+            }
+        }
+    }
+}

--- a/Consoul.sln
+++ b/Consoul.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Consoul", "Consoul\Consoul.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Consoul.Test", "Consoul.Test\Consoul.Test.csproj", "{B33DED30-F200-4FE7-91F8-1672FFD33797}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Consoul.Tests", "Consoul.Tests\Consoul.Tests.csproj", "{5C0F1CA0-6E46-430C-8D6C-FA37FBFCF7E9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -19,9 +21,13 @@ Global
 		{6E1BEE67-2F43-4F03-BCD9-254277CE1B26}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B33DED30-F200-4FE7-91F8-1672FFD33797}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B33DED30-F200-4FE7-91F8-1672FFD33797}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B33DED30-F200-4FE7-91F8-1672FFD33797}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B33DED30-F200-4FE7-91F8-1672FFD33797}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {B33DED30-F200-4FE7-91F8-1672FFD33797}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B33DED30-F200-4FE7-91F8-1672FFD33797}.Release|Any CPU.Build.0 = Release|Any CPU
+                {5C0F1CA0-6E46-430C-8D6C-FA37FBFCF7E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {5C0F1CA0-6E46-430C-8D6C-FA37FBFCF7E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {5C0F1CA0-6E46-430C-8D6C-FA37FBFCF7E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {5C0F1CA0-6E46-430C-8D6C-FA37FBFCF7E9}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Consoul/Prompt/SelectionPrompt.cs
+++ b/Consoul/Prompt/SelectionPrompt.cs
@@ -234,7 +234,7 @@ namespace ConsoulLibrary
                 else
                 {
                     Int32.TryParse(input, out selection);
-                    if (selection <= 0 || selection > (_options.Count + 1))
+                    if (selection <= 0 || selection > _options.Count)
                     {
                         Consoul.WriteCore("Invalid selection!", RenderOptions.InvalidColor);
                         selection = -1;


### PR DESCRIPTION
## Summary
- fix SelectionPrompt numeric validation to reject values greater than the option count
- add an xUnit test project with coverage for the regression scenario
- register the new test project in the solution file

## Testing
- dotnet test *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_6903667b36d883329fc868aec0e70267